### PR TITLE
fix Lift detected dockerfile bug-type: DL3019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 FROM node:16.13.2-alpine3.15 as yarn-build
 LABEL stage=builder
 
-RUN apk add --update build-base
+RUN apk add --no-cache build-base
 
 WORKDIR /src
 
@@ -28,7 +28,7 @@ RUN make yarn
 FROM golang:1.16.2-alpine AS build
 LABEL stage=builder
 
-RUN apk add --update build-base ca-certificates git
+RUN apk add --no-cache build-base ca-certificates git
 
 ENV USER=bbashuser
 ENV UID=10001 


### PR DESCRIPTION
Do the good thing Lift suggested doing: use --no-cache when building apk docker image. 