### PR TITLE
Disable TLS 1.0 and 1.1 by selecting a more secure SSL Policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -305,7 +305,7 @@ resource "aws_lb_target_group" "bug_bash_target_group" {
 resource "aws_lb_listener" "listener" {
   load_balancer_arn = "${aws_alb.bug_bash_application_load_balancer.arn}"
   certificate_arn   = aws_acm_certificate.this.arn
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   port              = "443"
   protocol          = "HTTPS"
 


### PR DESCRIPTION
Use an SSL Policy that does not support the deprecated TLS 1.0 and 1.1 protocols.